### PR TITLE
gale: Add TARGET_DISABLE_EPPE

### DIFF
--- a/lineage_gale.mk
+++ b/lineage_gale.mk
@@ -44,6 +44,8 @@ TARGET_SUPPORTS_GOOGLE_RECORDER := true
 # Exclude Aperture camera
 PRODUCT_NO_CAMERA := false
 
+#EPPE
+TARGET_DISABLE_EPPE := true
 
 PRODUCT_GMS_CLIENTID_BASE := android-xiaomi
 


### PR DESCRIPTION
Due to error:
Offending entries:
GCamGOPrebuilt
android.hardware.drm@1.4-service.clearkey
android.hardware.graphics.composer@2.4-impl
android.hardware.thermal@2.0-service.pixel
libbthost_if.vendor
libdisplayconfig.qti.vendor
libjson.vendor
libldacBT_bco
libldacBT_bco.vendor
liblhdc
liblhdcBT_dec
liblhdcBT_enc
liblhdcdec
libqsap_sdk
thermal_symlinks
build/make/core/main.mk:1375: error: Build failed.